### PR TITLE
Update ConvertContainer.js

### DIFF
--- a/src/Components/Footer/ConvertContainer.js
+++ b/src/Components/Footer/ConvertContainer.js
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react'
 
 import ColorContext from '../../context/ColorContext';
-import { HSLtoRGB, RGBtoHEX, HEXtoRGB, RGBtoHSL } from '../../pureFunctions'
+import { HSLtoRGB, RGBtoHEX, HEXtoRGB, RGBtoHSL } from '../../PureFunctions';
 import LeftConvertPanel from './LeftConvertPanel';
 import RightConvertPanel from './RightConvertPanel';
 


### PR DESCRIPTION
Capital `P` is necessary for app to compile on case-sensitive operating systems (e.g., Linux).
Also, you're missing a `;`.